### PR TITLE
Updated tomcat9 SOURCE_URL to version 9.0.58

### DIFF
--- a/conf/tomcat9_deb.src
+++ b/conf/tomcat9_deb.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://ftp.debian.org/debian/pool/main/t/tomcat9/tomcat9_9.0.55-1_all.deb
-SOURCE_SUM=6a26866987278e31ade7174b5ba9d687beb69234db95155263c1e66e582fecce
+SOURCE_URL=https://ftp.debian.org/debian/pool/main/t/tomcat9/tomcat9_9.0.58-1_all.deb
+SOURCE_SUM=d63612224bbd2ed489d8b427bc8543b82aea1d3cfbb850c2a1489f080f50b808
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=ar
 SOURCE_IN_SUBDIR=false


### PR DESCRIPTION
## Problem

- Installating Apache Guacamole results in ERROR 404 due to tomcat9 no longer exist on the server

## Solution

- Updated SOURCE_URL to the latest available version on the server and updated the SHA256 checksum

## PR Status

- [  ] Code finished and ready to be reviewed/tested
- [ Y ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
