### PR TITLE
Change tomcat9 link

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -80,7 +80,7 @@ ram.runtime = "50M"
     rename = "mariadb-java-client.jar"
 
     [resources.sources.tomcat9_deb]
-    url = "https://ftp.debian.org/debian/pool/main/t/tomcat9/tomcat9_9.0.43-2~deb11u9_all.deb"
+    url = "https://ftp.debian.org/debian/pool/main/t/tomcat9/tomcat9_9.0.43-2~deb11u10_all.deb"
     sha256 = "e016d55fd13bb51906106ede43fd970001f9b23db89628ddcbcca11e10a6068f"
     format = "whatever"
     extract = false

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Guacamole"
 description.en = "Clientless remote desktop gateway. It supports standard protocols like VNC, RDP, and SSH"
 description.fr = "Service de bureau à distance sans client. Fonctionne avec des protocoles standard comme VNC, RDP, et SSH"
 
-version = "1.5.4~ynh1"
+version = "1.5.4~ynh2"
 
 maintainers = ["Jules Bertholet"]
 
@@ -81,7 +81,7 @@ ram.runtime = "50M"
 
     [resources.sources.tomcat9_deb]
     url = "https://ftp.debian.org/debian/pool/main/t/tomcat9/tomcat9_9.0.43-2~deb11u10_all.deb"
-    sha256 = "e016d55fd13bb51906106ede43fd970001f9b23db89628ddcbcca11e10a6068f"
+    sha256 = "0dd30fee78ecd3980e9ee3ba018071755ddf84e2288b860900709f1013e368ed"
     format = "whatever"
     extract = false
     rename = "tomcat9.deb"


### PR DESCRIPTION
## Problem

- When I try to install Apache Guacamole, I get an error telling me that YunoHost cannot download the Tomcat .deb ( 404 Not Found).

## Solution

- Change tomcat9 link in manifest.toml

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
