### PR TITLE
Fix the connection to RDP. The user running guacd must have a writable home directory

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -42,7 +42,7 @@ fi
 ynh_script_progression --message="Configuring system users..." --weight=1
 
 # Create system users
-ynh_system_user_create --username="$app-guacd" --groups="$app"
+ynh_system_user_create --username="$app-guacd" --groups="$app" --home_dir="/home/$app-guacd"
 ynh_system_user_create --username="$app-tomcat" --groups="$app"
 
 #=================================================


### PR DESCRIPTION
Because the FreeRDP libraries must be able to write certificate information out to the directory. Configure guacd to run under an account that has a writable home directory.

## Problem

- After a fresh install, Guacamole is not able to connect to any remote desktop in RDP because log in failed. Deconnection occurs in a second after the connection attempt.

![signal-2024-12-27-144608_002](https://github.com/user-attachments/assets/5c3b58e0-c807-461a-85a6-1a22daf15a49)

## Solution

- Guacd need a home directory in order to store files like certificates. So i've juts add the `--home_dir` argument to the `ynh_system_user_create` function

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
