### PR TITLE
Use url from apache archives instead of dlcdn because old packages ar…

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -50,8 +50,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.tomcat9]
-    url = "https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz"
-    sha256 = "1d9a1104c2e235a5baff6e9ca8e28be3d864803fafc478f5c13c2ae6a5ed3d6f"
+    url = "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.100/bin/apache-tomcat-9.0.100.tar.gz"
+    sha256 = "1253158c45a31a8168b41436512acc2292e94a3468b1bd8e4d0a7a79dcc1f5ff"
 
     [resources.sources.server]
     url = "https://downloads.apache.org/guacamole/1.5.5/source/guacamole-server-1.5.5.tar.gz"


### PR DESCRIPTION
…e removed. Tomcat version is updated to version V9.0.100

## Problem

- Installation of the guacamole application failed because the url to download tomcat server was unavailable

## Solution

- I just changed the url from dlcdn.apache.org to archive.apache.org. dlcdn seems to provide only the last 2 version of tomcat but archive provide all the versions. I also update the tomcat version from 9.0.98 to 9.0.100.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
